### PR TITLE
Do not fix a container name

### DIFF
--- a/src/connect.js
+++ b/src/connect.js
@@ -7,7 +7,6 @@ export function connect(getters, actions) {
 
   return function(name, Component) {
     const container = Vue.extend({
-      name: `${name}-container`,
       components: {
         [name]: Component
       }


### PR DESCRIPTION
It seems to prefer a user-definable container name than a fixed container name.