### PR TITLE
Allow container props

### DIFF
--- a/src/connect.js
+++ b/src/connect.js
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import { camelToKebab, assign, pick, mapValues } from './utils';
+import { camelToKebab, assign, pick, omit, mapValues } from './utils';
 
 const VERSION = Number(Vue.version.split('.')[0]);
 
@@ -31,8 +31,10 @@ export function connect(getters, actions, lifecycle) {
 
   return function(name, Component) {
     const propKeys = Object.keys(getters).concat(Object.keys(actions));
+    const containerProps = omit(Component.options.props, propKeys);
 
     const options = {
+      props: containerProps,
       components: {
         [name]: Component
       },
@@ -42,7 +44,7 @@ export function connect(getters, actions, lifecycle) {
       }
     };
 
-    insertRenderer(options, name, propKeys);
+    insertRenderer(options, name, propKeys.concat(Object.keys(containerProps)));
 
     const lifecycle_ = mapValues(pick(lifecycle, LIFECYCLE_KEYS), f => {
       return function() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,10 +23,24 @@ export function pick(obj, keys) {
   return res;
 }
 
+export function omit(obj, keys) {
+  const res = {};
+  Object.keys(obj).forEach(key => {
+    if (!includes(keys, key)) {
+      res[key] = obj[key];
+    }
+  });
+  return res;
+}
+
 export function mapValues(obj, f) {
   const res = {};
   Object.keys(obj).forEach(key => {
     res[key] = f(obj[key], key);
   });
   return res;
+}
+
+function includes(array, item) {
+  return array.indexOf(item) > -1;
 }

--- a/test/connect.js
+++ b/test/connect.js
@@ -181,13 +181,26 @@ describe('connect', () => {
     assert(c.e === void 0);
     assert(c.foo === void 0);
   });
+
+  it('passes container props to component props if no getters and actions are specified', () => {
+    const C = connect({
+      a: state => state.foo,
+      b: state => state.bar
+    })('example', Component);
+
+    const c = mountContainer(store, C, { a: 1, c: 'test' });
+
+    assert(c.a === 'bar'); // should not override container props
+    assert(c.b === 5);
+    assert(c.c === 'test');
+  });
 });
 
-function mountContainer(store, Container) {
+function mountContainer(store, Container, props) {
   const app = new Vue({
     el: '#app',
     store,
-    render: h => h(Container)
+    render: h => h(Container, { props })
   });
   return app.$children[0];
 }

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,5 +1,5 @@
 import assert from 'power-assert';
-import { camelToKebab, assign, pick, mapValues } from '../src/utils';
+import { camelToKebab, assign, pick, omit, mapValues } from '../src/utils';
 
 describe('utils', () => {
 
@@ -42,6 +42,15 @@ describe('utils', () => {
       const actual = pick(a, ['a', 'c', 'e']);
 
       assert.deepEqual(actual, { a: 1, c: 1 });
+    });
+  });
+
+  describe('omit', () => {
+    it('omits specified properties', () => {
+      const a = { a: 1, b: 1, c: 1, d: 1 };
+      const actual = omit(a, ['a', 'c', 'e']);
+
+      assert.deepEqual(actual, { b: 1, d: 1 });
     });
   });
 


### PR DESCRIPTION
Now if we don't specify getters or actions for props defined on a wrapped component, the container will receive its props in the same name.

e.g. 
```js
// component
const Component = {
  props: ['a', 'b'],
  template: `<ul>
    <li>a = {{ a }}</li>
    <li>b = {{ b }}</li>
  </ul>`
}

// container
const Container = connect(
  { a: state => state.a } // prop 'b' is not specified on container
)('component', Component)

const OtherComponent = {
  // container can receives 'b' from its props and pass it to the wrapped component
  template: `<container :b="'Test'"></container>`,
  components: { Container }
}
```