### PR TITLE
Support Vuex 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,12 +45,12 @@
     "power-assert": "^1.3.1",
     "run-sequence": "^1.1.5",
     "testem": "^1.6.0",
-    "vue": "^2.0.0-alpha.7",
-    "vuex": "^1.0.0-rc.2",
+    "vue": "^2.0.0-rc.1",
+    "vuex": "^2.0.0-rc.4",
     "webpack": "^1.13.0"
   },
   "peerDependencies": {
     "vue": "^1.0.21 || ^2.0.0-alpha.0",
-    "vuex": ">=0.6.2 <1.0.0 || ^1.0.0-rc"
+    "vuex": "^2.0.0-rc"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-preset-power-assert": "^1.0.0",
     "babel-preset-stage-3": "^6.5.0",
     "del": "^2.2.0",
+    "es6-promise": "^3.2.1",
     "eslint": "^3.0.0",
     "glob": "^7.0.3",
     "gulp": "^3.9.1",

--- a/src/connect.js
+++ b/src/connect.js
@@ -9,7 +9,7 @@ import {
 
 import {
   camelToKebab,
-  assign,
+  merge,
   pick,
   omit,
   keys,
@@ -74,14 +74,14 @@ export function connect(options = {}) {
       components: {
         [name]: Component
       },
-      computed: assign({},
+      computed: merge(
         mapState(stateToProps),
         mapGetters(gettersToProps)
       ),
-      methods: assign({},
-        mapActions(assign({}, actionsToProps, actionsToEvents)),
-        mapMutations(assign({}, mutationsToProps, mutationsToEvents)),
-        mapValues(assign({}, methodsToProps, methodsToEvents), bindStore)
+      methods: merge(
+        mapActions(merge(actionsToProps, actionsToEvents)),
+        mapMutations(merge(mutationsToProps, mutationsToEvents)),
+        mapValues(merge(methodsToProps, methodsToEvents), bindStore)
       )
     };
 

--- a/src/connect.js
+++ b/src/connect.js
@@ -12,6 +12,7 @@ import {
   assign,
   pick,
   omit,
+  keys,
   mapValues
 } from './utils';
 
@@ -50,13 +51,17 @@ export function connect(options = {}) {
   } = options;
 
   return function(name, Component) {
-    const propKeys = Object.keys(stateToProps)
-      .concat(Object.keys(gettersToProps))
-      .concat(Object.keys(actionsToProps))
-      .concat(Object.keys(mutationsToProps));
+    const propKeys = keys(
+      stateToProps,
+      gettersToProps,
+      actionsToProps,
+      mutationsToProps
+    );
 
-    const eventKeys = Object.keys(actionsToEvents)
-      .concat(Object.keys(mutationsToEvents));
+    const eventKeys = keys(
+      actionsToEvents,
+      mutationsToEvents
+    );
 
     const containerProps = omit(getProps(Component), propKeys);
 

--- a/src/connect.js
+++ b/src/connect.js
@@ -50,7 +50,7 @@ export function connect(options = {}) {
     methodsToProps = {},
     methodsToEvents = {},
     lifecycle = {}
-  } = options;
+  } = mapValues(options, normalizeOptions);
 
   return function(name, Component) {
     const propKeys = keys(
@@ -139,4 +139,13 @@ function bindStore(fn) {
   return function boundFunctionWithStore(...args) {
     return fn.call(this, this.$store, ...args);
   };
+}
+
+function normalizeOptions(options) {
+  return Array.isArray(options)
+    ? options.reduce((obj, value) => {
+      obj[value] = value;
+      return obj;
+    }, {})
+    : options;
 }

--- a/src/connect.js
+++ b/src/connect.js
@@ -47,6 +47,8 @@ export function connect(options = {}) {
     actionsToEvents = {},
     mutationsToProps = {},
     mutationsToEvents = {},
+    methodsToProps = {},
+    methodsToEvents = {},
     lifecycle = {}
   } = options;
 
@@ -55,12 +57,14 @@ export function connect(options = {}) {
       stateToProps,
       gettersToProps,
       actionsToProps,
-      mutationsToProps
+      mutationsToProps,
+      methodsToProps
     );
 
     const eventKeys = keys(
       actionsToEvents,
-      mutationsToEvents
+      mutationsToEvents,
+      methodsToEvents
     );
 
     const containerProps = omit(getProps(Component), propKeys);
@@ -76,7 +80,8 @@ export function connect(options = {}) {
       ),
       methods: assign({},
         mapActions(assign({}, actionsToProps, actionsToEvents)),
-        mapMutations(assign({}, mutationsToProps, mutationsToEvents))
+        mapMutations(assign({}, mutationsToProps, mutationsToEvents)),
+        mapValues(assign({}, methodsToProps, methodsToEvents), bindStore)
       )
     };
 
@@ -128,4 +133,10 @@ function getProps(Component) {
 
 function bindProp(key) {
   return `:${camelToKebab(key)}="${key}"`;
+}
+
+function bindStore(fn) {
+  return function boundFunctionWithStore(...args) {
+    return fn.call(this, this.$store, ...args);
+  };
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -42,9 +42,8 @@ export function mapValues(obj, f) {
   return res;
 }
 
-// It does not care about duplicated keys
 export function keys(...args) {
-  return args.reduce((ks, obj) => ks.concat(Object.keys(obj)), []);
+  return Object.keys(merge(...args));
 }
 
 function includes(array, item) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,7 +4,8 @@ export function camelToKebab(str) {
     .toLowerCase();
 }
 
-export function assign(target, ...args) {
+export function merge(...args) {
+  const target = {};
   args.forEach(obj => {
     Object.keys(obj).forEach(key => {
       target[key] = obj[key];

--- a/src/utils.js
+++ b/src/utils.js
@@ -41,6 +41,11 @@ export function mapValues(obj, f) {
   return res;
 }
 
+// It does not care about duplicated keys
+export function keys(...args) {
+  return args.reduce((ks, obj) => ks.concat(Object.keys(obj)), []);
+}
+
 function includes(array, item) {
   return array.indexOf(item) > -1;
 }

--- a/test/connect.js
+++ b/test/connect.js
@@ -9,31 +9,34 @@ import Vuex from 'vuex';
 Vue.use(Vuex);
 
 describe('connect', () => {
-  let state, mutations, store, options, Component;
+  const TEST = 'TEST';
+  let state, getters, actions, mutations, store, options, Component;
 
   beforeEach(() => {
     setup();
 
     state = {
-      foo: 'bar',
-      bar: 5,
-      baz: true
+      foo: 'foo'
+    };
+
+    getters = {
+      foo: state => state.foo
+    };
+
+    actions = {
+      [TEST]({ commit }, value) { commit('TEST', value + value); }
     };
 
     mutations = {
-      UPDATE_FOO(state, value) { state.foo = value; },
-      UPDATE_BAR(state, value) { state.bar = value; }
+      [TEST](state, value) { state.foo = value; }
     };
 
-    store = new Vuex.Store({ state, mutations });
+    store = new Vuex.Store({ state, getters, actions, mutations });
 
     options = {
-      props: ['a', 'b', 'c'],
+      props: ['a', 'b'],
       render(h) {
-        return h('div', null, [
-          h('div', { id: 'component-prop-1' }, this.a),
-          h('div', { id: 'component-prop-2' }, this.b)
-        ]);
+        return h('div');
       }
     };
 
@@ -55,60 +58,44 @@ describe('connect', () => {
     assert(actual.$options._componentTag === 'test');
   });
 
-  it('binds getter functions', () => {
+  it('binds state mapping to component props', done => {
     const Container = connect({
-      gettersToProps: {
-        a: (state) => state.foo,
-        b: (state) => state.bar
-      }
-    })('example', Component);
-
-    const actual = mountContainer(store, Container);
-
-    assert(actual.a === 'bar');
-    assert(actual.b === 5);
-  });
-
-  it('binds actions', () => {
-    const Container = connect({
-      actionsToProps: {
-        c: ({ dispatch }, value) => dispatch('UPDATE_FOO', value)
-      },
-      actionsToEvents: {
-        d: ({ dispatch }, value) => dispatch('UPDATE_FOO', value)
-      }
-    })('example', Component);
-
-    const actual = mountContainer(store, Container);
-
-    assert(store.state.foo === 'bar');
-    actual.c('baz');
-    assert(store.state.foo === 'baz');
-    actual.d('foo');
-    assert(store.state.foo === 'foo');
-  });
-
-  it('binds getter values to component props', (done) => {
-    const Container = connect({
-      gettersToProps: {
-        a: (state) => state.foo,
-        b: (state) => state.bar + 3,
-        z: (state) => state.baz
+      stateToProps: {
+        a: (state) => state.foo
       }
     })('example', Component);
 
     const container = mountContainer(store, Container);
     const actual = container.$children[0];
 
-    assert(actual.a === 'bar');
-    assert(actual.b === 8);
-    assert(actual.z === void 0); // z is not registered on props
+    assert(actual.a === 'foo');
 
-    store.state.foo = 'baz';
+    store.state.foo = 'bar';
 
     actual.$nextTick(() => {
       // ensure the props can detect changes
-      assert(actual.a === 'baz');
+      assert(actual.a === 'bar');
+      done();
+    });
+  });
+
+  it('binds getters to component props', done => {
+    const Container = connect({
+      gettersToProps: {
+        a: 'foo'
+      }
+    })('example', Component);
+
+    const container = mountContainer(store, Container);
+    const actual = container.$children[0];
+
+    assert(actual.a === 'foo');
+
+    store.state.foo = 'bar';
+
+    actual.$nextTick(() => {
+      // ensure the props can detect changes
+      assert(actual.a === 'bar');
       done();
     });
   });
@@ -116,36 +103,69 @@ describe('connect', () => {
   it('binds actions to component props', () => {
     const Container = connect({
       actionsToProps: {
-        c: ({ dispatch }, value) => dispatch('UPDATE_BAR', value * 2)
+        a: TEST
       }
     })('example', Component);
 
     const container = mountContainer(store, Container);
     const actual = container.$children[0];
 
-    assert(store.state.bar === 5);
-    actual.c(10);
-    assert(store.state.bar === 20);
+    assert(store.state.foo === 'foo');
+    actual.a('bar');
+    assert(store.state.foo === 'barbar');
   });
 
   it('binds actions to component events', () => {
     const Container = connect({
       actionsToEvents: {
-        camelEvent: ({ dispatch }, value) => dispatch('UPDATE_FOO', value),
-        'kebab-event': ({ dispatch }, value) => dispatch('UPDATE_BAR', value)
+        camelEvent: TEST,
+        'kebab-event': TEST
       }
     })('example', Component);
 
     const container = mountContainer(store, Container);
     const actual = container.$children[0];
 
-    assert(store.state.foo === 'bar');
-    actual.$emit('camelEvent', 'baz');
-    assert(store.state.foo === 'baz');
+    assert(store.state.foo === 'foo');
+    actual.$emit('camelEvent', 'bar');
+    assert(store.state.foo === 'barbar');
 
-    assert(store.state.bar === 5);
-    actual.$emit('kebab-event', 10);
-    assert(store.state.bar === 10);
+    actual.$emit('kebab-event', 'baz');
+    assert(store.state.foo === 'bazbaz');
+  });
+
+  it('binds mutations to component props', () => {
+    const Container = connect({
+      mutationsToProps: {
+        a: TEST
+      }
+    })('example', Component);
+
+    const container = mountContainer(store, Container);
+    const actual = container.$children[0];
+
+    assert(store.state.foo === 'foo');
+    actual.a('bar');
+    assert(store.state.foo === 'bar');
+  });
+
+  it('binds mutations to component events', () => {
+    const Container = connect({
+      mutationsToEvents: {
+        camelEvent: TEST,
+        'kebab-event': TEST
+      }
+    })('example', Component);
+
+    const container = mountContainer(store, Container);
+    const actual = container.$children[0];
+
+    assert(store.state.foo === 'foo');
+    actual.$emit('camelEvent', 'bar');
+    assert(store.state.foo === 'bar');
+
+    actual.$emit('kebab-event', 'baz');
+    assert(store.state.foo === 'baz');
   });
 
   it('injects lifecycle hooks', (done) => {
@@ -173,7 +193,6 @@ describe('connect', () => {
     })('example', Component);
 
     const c = mountContainer(store, C);
-    store.dispatch('UPDATE_FOO', 'foo');
     c.$forceUpdate();
 
     Vue.nextTick(() => {
@@ -183,76 +202,34 @@ describe('connect', () => {
     });
   });
 
-  it('does not allow other than lifecycle hooks', () => {
-    const a = s => s.foo;
-    const b = s => s.state.bar;
-
-    const C = connect({
-      gettersToProps: {
-        a: a
-      },
-      actionsToProps: {
-        b: b
-      },
-      lifecycle: {
-        a: 1,
-        b: 1,
-        methods: {
-          c: () => 1
-        },
-        vuex: {
-          getters: {
-            a: s => s.bar,
-            d: () => 1
-          },
-          actions: {
-            b: s => s.state.foo,
-            e: () => 1
-          }
-        }
-      }
-    })('example', Component);
-
-    const c = mountContainer(store, C);
-
-    assert(c.a === a(store.state));
-    assert(c.b() === b(store));
-    assert(c.c === void 0);
-    assert(c.d === void 0);
-    assert(c.e === void 0);
-    assert(c.foo === void 0);
-  });
-
   it('passes container props to component props if no getters and actions are specified', () => {
     const C = connect({
       gettersToProps: {
-        a: state => state.foo,
-        b: state => state.bar
+        a: 'foo'
       }
     })('example', Component);
 
-    const c = mountContainer(store, C, { a: 1, c: 'test' });
+    const c = mountContainer(store, C, { a: 1, b: 'test' });
 
-    assert(c.a === 'bar'); // should not override container props
-    assert(c.b === 5);
-    assert(c.c === 'test');
+    assert(c.a === 'foo'); // should not override container props
+    assert(c.b === 'test');
   });
 
   it('accepts component options for wrapped component', () => {
     const C = connect({
       gettersToProps: {
-        a: state => state.foo
+        a: 'foo'
       },
       actionsToProps: {
-        c: ({ dispatch }, value) => dispatch('UPDATE_FOO', value)
+        b: TEST
       }
     })('example', options);
 
     const c = mountContainer(store, C);
 
-    assert(c.a === 'bar');
-    c.c('baz');
-    assert(c.a === 'baz');
+    assert(c.a === 'foo');
+    c.b('bar');
+    assert(c.a === 'barbar');
   });
 });
 

--- a/test/connect.js
+++ b/test/connect.js
@@ -168,6 +168,48 @@ describe('connect', () => {
     assert(store.state.foo === 'baz');
   });
 
+  it('binds inline functions to component props', () => {
+    const Container = connect({
+      methodsToProps: {
+        a: (_store, value) => {
+          assert(_store === store);
+          _store.commit(TEST, value);
+        }
+      }
+    })('example', Component);
+
+    const container = mountContainer(store, Container);
+    const actual = container.$children[0];
+
+    assert(store.state.foo === 'foo');
+    actual.a('bar');
+    assert(store.state.foo === 'bar');
+  });
+
+  it('binds inline functions to component events', () => {
+    const fn = (_store, value) => {
+      assert(_store === store);
+      _store.commit(TEST, value);
+    };
+
+    const Container = connect({
+      methodsToEvents: {
+        camelEvent: fn,
+        'kebab-event': fn
+      }
+    })('example', Component);
+
+    const container = mountContainer(store, Container);
+    const actual = container.$children[0];
+    
+    assert(store.state.foo === 'foo');
+    actual.$emit('camelEvent', 'bar');
+    assert(store.state.foo === 'bar');
+
+    actual.$emit('kebab-event', 'baz');
+    assert(store.state.foo === 'baz');
+  });
+
   it('injects lifecycle hooks', (done) => {
     let C;
     let count = 0;

--- a/test/connect.js
+++ b/test/connect.js
@@ -34,7 +34,7 @@ describe('connect', () => {
     store = new Vuex.Store({ state, getters, actions, mutations });
 
     options = {
-      props: ['a', 'b'],
+      props: ['a', 'b', 'foo', TEST],
       render(h) {
         return h('div');
       }
@@ -201,13 +201,31 @@ describe('connect', () => {
 
     const container = mountContainer(store, Container);
     const actual = container.$children[0];
-    
+
     assert(store.state.foo === 'foo');
     actual.$emit('camelEvent', 'bar');
     assert(store.state.foo === 'bar');
 
     actual.$emit('kebab-event', 'baz');
     assert(store.state.foo === 'baz');
+  });
+
+  it('allows array style binding', done => {
+    const Container = connect({
+      gettersToProps: ['foo'],
+      mutationsToEvents: [TEST]
+    })('example', Component);
+
+    const container = mountContainer(store, Container);
+    const actual = container.$children[0];
+
+    assert(actual.foo === 'foo');
+    actual.$emit(TEST, 'bar');
+
+    Vue.nextTick(() => {
+      assert(actual.foo === 'bar');
+      done();
+    });
   });
 
   it('injects lifecycle hooks', (done) => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,5 +1,5 @@
 import assert from 'power-assert';
-import { camelToKebab, assign, pick, omit, mapValues, keys } from '../src/utils';
+import { camelToKebab, merge, pick, omit, mapValues, keys } from '../src/utils';
 
 describe('utils', () => {
 
@@ -21,18 +21,19 @@ describe('utils', () => {
     });
   });
 
-  describe('assign', () => {
-    it('extends the first argument by latter arguments', () => {
+  describe('merge', () => {
+    it('merges given objects and should not mutate any objects', () => {
       const a = { a: 1, b: 1 };
-      const actual = assign(a, { a: 2, c: 1 }, { d: 1 }, { c: 2 });
+      const actual = merge(a, { a: 2, c: 1 }, { d: 1 }, { c: 2 });
 
-      assert.deepEqual(a, {
+      assert.deepEqual(actual, {
         a: 2,
         b: 1,
         c: 2,
         d: 1
       });
-      assert(a === actual);
+      assert.deepEqual(a, { a: 1, b: 1 }); // should not mutate
+      assert(a !== actual); // should create new object
     });
   });
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -69,8 +69,7 @@ describe('utils', () => {
     it('concats all objects\' keys', () => {
       const actual = keys({ a: 'a', b: 0 }, { b: '', c: null }, { d: false });
 
-      // does not care about duplicated keys
-      assert.deepEqual(actual, ['a', 'b', 'b', 'c', 'd']);
+      assert.deepEqual(actual, ['a', 'b', 'c', 'd']);
     });
   });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,5 +1,5 @@
 import assert from 'power-assert';
-import { camelToKebab, assign, pick, omit, mapValues } from '../src/utils';
+import { camelToKebab, assign, pick, omit, mapValues, keys } from '../src/utils';
 
 describe('utils', () => {
 
@@ -61,6 +61,15 @@ describe('utils', () => {
       const actual = mapValues(a, f);
 
       assert.deepEqual(actual, { a: 2, b: 3, c: 4 });
+    });
+  });
+
+  describe('keys', () => {
+    it('concats all objects\' keys', () => {
+      const actual = keys({ a: 'a', b: 0 }, { b: '', c: null }, { d: false });
+
+      // does not care about duplicated keys
+      assert.deepEqual(actual, ['a', 'b', 'b', 'c', 'd']);
     });
   });
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,6 +25,12 @@ module.exports = {
       commonjs2: 'vue',
       commonjs: 'vue',
       amd: 'vue'
+    },
+    vuex: {
+      root: 'Vuex',
+      commonjs2: 'vuex',
+      commonjs: 'vuex',
+      amd: 'vuex'
     }
   }
 };

--- a/webpack.config.test.js
+++ b/webpack.config.test.js
@@ -9,7 +9,7 @@ conf.debug = true;
 conf.devtool = 'source-map';
 
 conf.context = path.resolve(__dirname);
-conf.entry = glob.sync('./test/**/*.js');
+conf.entry = ['es6-promise'].concat(glob.sync('./test/**/*.js'));
 conf.output = {
   path: path.resolve(__dirname, '.tmp'),
   filename: 'test.js'


### PR DESCRIPTION
fix #22 

## Breaking Changes

- No longer support Vuex <= 1.0.
- `gettersToProps`, `actionsToProps` and `actionsToEvents` have become similar interface of Vuex's `mapGetters` and `mapActions`.

  ```js
  export default connect({
    gettersToProps: {
      computedName: 'getterName'
    },
    actionsToEvents: {
      'event-name': ACTION_NAME
    }
  })('example', ExampleComponent)
  ```

## New

- `stateToProps`
- `mutationsToProps` and `mutationsToEvents`
- `methodsToProps` and `methodsToEvents`

`stateToProps`, `mutationsToProps` and `mutationsToEvents` are similar to Vuex's `mapState` and `mapMutations`. `stateToProps` is same as old `gettersToProps`.

`methodsToProps` and `methodsToEvents` allow to define inline methods to `dispatch` or `commit` to Vuex store. They receive injected store as 1st argument and are similar to old `actionsTo(Props|Events)`

```js
export default connect({
  stateToProps: {
    foo: state => state.foo
  },
  mutationsToEvents: {
    bar: BAR_MUTATION
  },
  methodsToEvents: {
    baz: ({ commit }, value) => {
      commit(BAZ_MUTATION, value)
    }
  }
})('example', ExampleComponent)
```
