### PR TITLE
Set a name on the component wrapper

### DIFF
--- a/src/connect.js
+++ b/src/connect.js
@@ -75,6 +75,7 @@ export function connect(options = {}) {
     const containerProps = omit(getOptions(Component).props || {}, propKeys)
 
     const options = {
+      name: `connect-${name}`,
       props: containerProps,
       components: {
         [name]: Component

--- a/test/connect.js
+++ b/test/connect.js
@@ -50,6 +50,11 @@ describe('connect', () => {
     assert(typeof actual === 'function')
   })
 
+  it('sets a name on the wrapper component', () => {
+    const actual = connect()('example', Component)
+    assert(actual.options.name === 'connect-example')
+  })
+
   it('sets name to given component', () => {
     const Container = connect()('test', Component)
     const { wrapped } = mountContainer(store, Container)


### PR DESCRIPTION
This makes it easier to navigate the component tree when using Vue devtools (react-redux does the same thing).