### PR TITLE
Add createConnect function

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,52 @@ The lifecycle hooks receives Vuex store for their first argument. You can dispat
 
 `connect` returns another function. The function expects a component name and the component constructor. The component name should be `string` and it is useful to specify the component on debug phase.
 
+### `createConnect(fn) -> ConnectFunction`
+
+Create customized `connect` function. `fn` is transform function of the wrapper component options and will receive component options object and lifecycle option of connect function. You may want to inject some additional lifecycle hooks in `fn`.
+
+Example of defining vue-router lifecycle hooks:
+
+```js
+// connect.js
+import { createConnect } from 'vuex-connect'
+
+export const connect = createConnect((options, lifecycle) => {
+  options.beforeRouteEnter = lifecycle.beforeRouteEnter
+
+  options.beforeRouteUpdate = function(to, from, next) {
+    return lifecycle.beforeRouteUpdate.call(this, this.store, to, from, next)
+  }
+
+  options.beforeRouteLeave = function(to, from, next) {
+    return lifecycle.beforeRouteLeave.call(this, this.store, to, from, next)
+  }
+})
+```
+
+It can be used as:
+
+```js
+import { connect } from './connect'
+import { Example } from './example'
+
+export default connect({
+  lifecycle: {
+    beforeRouteEnter(to, from, next) {
+      // ...
+    },
+
+    beforeRouteUpdate(store, to, from, next) {
+      // ...
+    },
+
+    beforeRouteLeave(store, to, from, next) {
+      // ...
+    }
+  }
+})('example', Example)
+```
+
 ## License
 
 MIT

--- a/scripts/webpack.config.test.js
+++ b/scripts/webpack.config.test.js
@@ -2,7 +2,8 @@ const path = require('path')
 const glob = require('glob')
 
 module.exports = {
-  entry: ['es6-promise'].concat(glob.sync(path.resolve(__dirname, '../test/**/*.js'))),
+  entry: ['es6-promise', path.resolve(__dirname, '../test/setup.js')]
+    .concat(glob.sync(path.resolve(__dirname, '../test/**/*.js'))),
   output: {
     path: path.resolve(__dirname, '../.tmp'),
     filename: 'test.js'

--- a/src/connect.js
+++ b/src/connect.js
@@ -39,7 +39,7 @@ const LIFECYCLE_KEYS = [
   'deactivated'
 ]
 
-export function connect(options = {}) {
+export const createConnect = transform => (options = {}) => {
   const {
     stateToProps = {},
     gettersToProps = {},
@@ -93,6 +93,10 @@ export function connect(options = {}) {
 
     insertLifecycleMixin(options, lifecycle)
     insertRenderer(options, name, propKeys.concat(Object.keys(containerProps)), eventKeys)
+
+    if (transform) {
+      transform(options, lifecycle)
+    }
 
     return Vue.extend(options)
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,4 @@
-export * from './connect'
+import { createConnect } from './connect'
+
+export const connect = createConnect()
+export { createConnect }

--- a/test/connect.js
+++ b/test/connect.js
@@ -6,8 +6,6 @@ import { connect } from '../src/connect'
 import Vue from 'vue'
 import Vuex from 'vuex'
 
-Vue.use(Vuex)
-
 describe('connect', () => {
   const TEST = 'TEST'
   let state, getters, actions, mutations, store, options, Component

--- a/test/connect.js
+++ b/test/connect.js
@@ -1,7 +1,7 @@
 import assert from 'power-assert'
 import { setup, teardown } from './stub/dom'
 
-import { connect } from '../src/connect'
+import { connect } from '../src'
 
 import Vue from 'vue'
 import Vuex from 'vuex'

--- a/test/create.js
+++ b/test/create.js
@@ -1,0 +1,41 @@
+import assert from 'power-assert'
+import Vue from 'vue'
+import Vuex from 'vuex'
+import { createConnect } from '../src'
+
+describe('createConnect', () => {
+  const store = new Vuex.Store({
+    state: {
+      value: 'foobar'
+    }
+  })
+
+  it('creates connect helper', () => {
+    const connect = createConnect(() => {})
+    assert(typeof connect === 'function')
+  })
+
+  it('transforms component options with lifecycle options', done => {
+    const connect = createConnect((options, lifecycle) => {
+      options.foo = function (arg) {
+        lifecycle.foo.call(this, this.$store, arg)
+      }
+    })
+
+    const Comp = connect({
+      lifecycle: {
+        foo (store, arg) {
+          assert(this instanceof Vue)
+          assert(store instanceof Vuex.Store)
+          assert(arg === 'test')
+          done()
+        }
+      }
+    })(Vue.extend({}))
+
+    const c = new Comp({
+      store
+    })
+    c.$options.foo.call(c, 'test')
+  })
+})

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,4 @@
+import Vue from 'vue'
+import Vuex from 'vuex'
+
+Vue.use(Vuex)


### PR DESCRIPTION
This function let the users create a customized `connect` helper. The users can define additional lifecycle hooks like vue-router's `beforeRouteEnter`.

Close #33 