### PR TITLE
Fix #53

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,38 @@ export default connect({
 })('hello', HelloComponent)
 ```
 
+You can use the visitor pattern in `gettersToProps` and `stateToProps` to 
+accept `mapGetters` and `mapState` respectively (to utilize their full
+API). This can allow you to use namespaced stores.
+
+``` js
+
+import { connect } from 'vuex-connect'
+import HelloComponent from './hello-component'
+
+export default connect({
+  stateToProps: (mapState) => ({
+    ...mapState('someNestedStore', {
+      nestedMessage: 'nestedValue',
+    }),
+    ...mapGetters({
+      message: 'inputMessage'
+    })
+  }),
+  gettersToProps: (mapGetters) => ({
+    ...mapGetters('someNestedStore', {
+      nestedMessage: 'nestedGetter',
+    }),
+    ...mapGetters({
+      encryptedMessage: 'encryptedInputMessage'
+    })
+  })
+})('hello', HelloComponent)
+
+```
+
+
+
 ## API
 
 ### `connect(options) -> (componentName, Component) -> WrapperComponent`


### PR DESCRIPTION
* Adds support for directly using mapState and mapGetters, enabling vuex namespaces. 
* Adds "handles namespaced state in stateToProps" and "handles namespaced getters in gettersToProps" tests
* Adds usage in README

Example:
```js
export default connect({
  stateToProps: (mapState) => ({
    ...mapState('someNestedStore', {
      nestedMessage: 'nestedValue',
    }),
    ...mapGetters({
      message: 'inputMessage'
    })
  })
})('hello', HelloComponent)
```